### PR TITLE
Added test to detect NA genus IDs #88

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,2 +1,2 @@
-
+library(stringr)
 resources <- load_taxonomic_resources(stable_or_current_data = "stable", version = "0.0.2.9000")

--- a/tests/testthat/test-consistency.R
+++ b/tests/testthat/test-consistency.R
@@ -124,3 +124,9 @@ test_that("handles NAs", {
     "Acacia aneura", NA
   ), resources = resources)), 0)
 })
+
+
+test_that("genus level ids", {
+  aliged_nms <- align_taxa(c("Acacia sp.", "Eucalyptus sp."), resources = resources) |> pull(aligned_name)
+  expect_false(any(str_detect(aliged_nms, "NA sp.")))
+})


### PR DESCRIPTION
Detects the NA sp. in `align_taxa`

This needs to be merged into master and then merged into [fix-genus-level-matches](https://github.com/traitecoevo/APCalign/tree/fix-genus-level-matches) before Lizzy's PR #94 gets merged