### PR TITLE
working on #93

### DIFF
--- a/R/create_taxonomic_update_lookup.R
+++ b/R/create_taxonomic_update_lookup.R
@@ -49,9 +49,10 @@ create_taxonomic_update_lookup <- function(taxa,
         updated_species_list,
         original_name,
         aligned_name,
-        apc_name = canonical_name,
+        updated_name = canonical_name,
+        author = scientificNameAuthorship,
         aligned_reason,
-        taxonomic_status_of_aligned_name = taxonomicStatusClean
+        updated_reason = taxonomicStatusClean
       ) %>%
         distinct()
     )

--- a/R/create_taxonomic_update_lookup.R
+++ b/R/create_taxonomic_update_lookup.R
@@ -12,6 +12,8 @@
 #' @param resources These are the taxonomic resources used for cleaning, this will default to loading them from a local place on your computer.  If this is to be called repeatedly, it's much faster to load the resources using \code{\link{load_taxonomic_resources}} separately and pass the data in.
 #' @param output file path to save the intermediate output to
 #' @return A lookup table containing the original species names, the aligned species names, and additional taxonomic information such as taxon IDs and genera.
+#' @details
+#' `updated_reason` represents the taxonomic status of the aligned name
 #' @export
 #'
 #' @seealso \code{\link{load_taxonomic_resources}}
@@ -49,7 +51,8 @@ create_taxonomic_update_lookup <- function(taxa,
         updated_species_list,
         original_name,
         aligned_name,
-        updated_name = canonical_name,
+        accepted_name = canonical_name,
+        taxon_rank = taxonRank,
         author = scientificNameAuthorship,
         aligned_reason,
         updated_reason = taxonomicStatusClean

--- a/man/create_taxonomic_update_lookup.Rd
+++ b/man/create_taxonomic_update_lookup.Rd
@@ -36,6 +36,9 @@ A lookup table containing the original species names, the aligned species names,
 \description{
 This function takes a list of Australian plant species that needs to be reconciled with current taxonomy and generates a lookup table to help fix the taxonomy. The lookup table contains the original species names, the aligned species names, and additional taxonomic information such as taxon IDs and genera.
 }
+\details{
+\code{updated_reason} represents the taxonomic status of the aligned name
+}
 \examples{
 \donttest{resources <- load_taxonomic_resources()
 create_taxonomic_update_lookup(c("Eucalyptus regnans",


### PR DESCRIPTION
I think this is what we wanted in the last meeting

The thinking is that `Full=TRUE` gives you exactly APC style column names so that you can follow the logic back, but `Full=FALSE` gives you (hopefully) more understandable column names