### PR TITLE
ensure first matches only look for species/infraspecific

### DIFF
--- a/R/load_taxonomic_resources.R
+++ b/R/load_taxonomic_resources.R
@@ -97,6 +97,7 @@ load_taxonomic_resources <-
       taxonomic_resources$APC %>%
       dplyr::arrange(taxonomic_status) %>%
       dplyr::filter(taxon_rank %in% c("subspecies", "species", "form", "variety")) %>%
+      dplyr::filter(!stringr::str_detect(canonical_name, "[:space:]sp\\.$")) %>%
       dplyr::select(canonical_name,
                     scientific_name,
                     taxonomic_status,

--- a/R/match_taxa.R
+++ b/R/match_taxa.R
@@ -94,7 +94,7 @@ match_taxa <- function(
     )
   
   
-  
+  species_and_infraspecific <- c("species", "form", "variety", "subspecies", "series")
   ## Taxa that have been checked are moved from `taxa$tocheck` to `taxa$checked`
   ## These lines of code are repeated after each matching cycle to progressively move taxa from `tocheck` to `checked`
   
@@ -107,7 +107,8 @@ match_taxa <- function(
   # Taxon names that are an accepted scientific name, with authorship.
   
   i <-
-    taxa$tocheck$original_name %in% resources$`APC list (accepted)`$scientific_name
+    taxa$tocheck$original_name %in% resources$`APC list (accepted)`$scientific_name &&
+    taxa$tocheck$taxon_rank %in% species_and_infraspecific
   
   ii <-
     match(
@@ -138,7 +139,8 @@ match_taxa <- function(
   # Taxon names that are an APC-known scientific name, with authorship.
   
   i <-
-    taxa$tocheck$original_name %in% resources$`APC list (known names)`$scientific_name
+    taxa$tocheck$original_name %in% resources$`APC list (known names)`$scientific_name &&
+    taxa$tocheck$taxon_rank %in% species_and_infraspecific
   
   ii <-
     match(
@@ -168,7 +170,8 @@ match_taxa <- function(
   # match_06a: APC-accepted canonical name
   # Taxon names that are exact matches to APC-accepted canonical names, once filler words and punctuation are removed.
   i <-
-    taxa$tocheck$cleaned_name %in% resources$`APC list (accepted)`$canonical_name
+    taxa$tocheck$cleaned_name %in% resources$`APC list (accepted)`$canonical_name &&
+    taxa$tocheck$taxon_rank %in% species_and_infraspecific
   
   ii <-
     match(
@@ -198,7 +201,8 @@ match_taxa <- function(
   # match_06b: APC-known canonical name
   # Taxon names that are exact matches to APC-known canonical names, once filler words and punctuation are removed.
   i <-
-    taxa$tocheck$cleaned_name %in% resources$`APC list (known names)`$canonical_name
+    taxa$tocheck$cleaned_name %in% resources$`APC list (known names)`$canonical_name &&
+    taxa$tocheck$taxon_rank %in% species_and_infraspecific
   
   ii <-
     match(

--- a/R/match_taxa.R
+++ b/R/match_taxa.R
@@ -93,8 +93,6 @@ match_taxa <- function(
         fuzzy_match_genera(genus, resources$genera_APNI$canonical_name)
     )
   
-  
-  species_and_infraspecific <- c("species", "form", "variety", "subspecies", "series")
   ## Taxa that have been checked are moved from `taxa$tocheck` to `taxa$checked`
   ## These lines of code are repeated after each matching cycle to progressively move taxa from `tocheck` to `checked`
   
@@ -107,8 +105,7 @@ match_taxa <- function(
   # Taxon names that are an accepted scientific name, with authorship.
   
   i <-
-    taxa$tocheck$original_name %in% resources$`APC list (accepted)`$scientific_name &&
-    taxa$tocheck$taxon_rank %in% species_and_infraspecific
+    taxa$tocheck$original_name %in% resources$`APC list (accepted)`$scientific_name
   
   ii <-
     match(
@@ -139,8 +136,7 @@ match_taxa <- function(
   # Taxon names that are an APC-known scientific name, with authorship.
   
   i <-
-    taxa$tocheck$original_name %in% resources$`APC list (known names)`$scientific_name &&
-    taxa$tocheck$taxon_rank %in% species_and_infraspecific
+    taxa$tocheck$original_name %in% resources$`APC list (known names)`$scientific_name
   
   ii <-
     match(
@@ -170,8 +166,7 @@ match_taxa <- function(
   # match_06a: APC-accepted canonical name
   # Taxon names that are exact matches to APC-accepted canonical names, once filler words and punctuation are removed.
   i <-
-    taxa$tocheck$cleaned_name %in% resources$`APC list (accepted)`$canonical_name &&
-    taxa$tocheck$taxon_rank %in% species_and_infraspecific
+    taxa$tocheck$cleaned_name %in% resources$`APC list (accepted)`$canonical_name
   
   ii <-
     match(
@@ -201,8 +196,7 @@ match_taxa <- function(
   # match_06b: APC-known canonical name
   # Taxon names that are exact matches to APC-known canonical names, once filler words and punctuation are removed.
   i <-
-    taxa$tocheck$cleaned_name %in% resources$`APC list (known names)`$canonical_name &&
-    taxa$tocheck$taxon_rank %in% species_and_infraspecific
+    taxa$tocheck$cleaned_name %in% resources$`APC list (known names)`$canonical_name
   
   ii <-
     match(


### PR DESCRIPTION
When matches 5 & 6 (perfect APC matches) were moved to front of match list, I didn't consider these could now "capture" genus-level matches by mistake. So matches 5 & 6 now only consider species/infraspecific taxon names (in APC)