### PR TITLE
fix scientific_name_id

### DIFF
--- a/R/update_taxonomy.R
+++ b/R/update_taxonomy.R
@@ -495,8 +495,7 @@ update_taxonomy_APC_species_and_infraspecific_taxa <- function(data, resources, 
         dplyr::select(
           aligned_name,
           taxonomic_status_aligned,
-          accepted_name_usage_ID,
-          scientific_name_ID
+          accepted_name_usage_ID
         )
     ) %>%
     ## Second, find accepted names for each name in the species (and infraspecific taxon) list (sometimes they are the same)
@@ -515,6 +514,7 @@ update_taxonomy_APC_species_and_infraspecific_taxa <- function(data, resources, 
           accepted_name,
           taxonomic_status,
           scientific_name,
+          scientific_name_ID,
           family,
           subclass,
           taxon_distribution


### PR DESCRIPTION
For APC taxa, the scientific_name_id was the scientific_name_id  for the aligned name, not the accepted_name. This was because scientific_name_id  was merged in too early - it has been fixed.

Test running:
```
test_taxa <- c("Abrodictyum caudatum",
                "Cephalomanes caudatum",
                "Macroglena caudata",
                "Trichomanes caudatum")

create_taxonomic_update_lookup(test_taxa, resources = resources, full = TRUE)
```

Before fix, each taxon had a different scientific_name_id, representing the values for the aligned names (names in string). 

With the fix, all scientific_name_id's are identical, as `Abrodictyum caudatum` is the accepted name for all 4 taxa.