### PR TITLE
Refining graceful failing when GitHub is down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ inst/doc
 docs/
 /doc/
 /Meta/
+revdep/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: APCalign
 Title: Resolving Plant Taxon Names Using the Australian Plant Census
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(
   person(given = "Daniel", family = "Falster", role = c("aut", "cre", "cph"), email = "daniel.falster@unsw.edu.au", comment = c(ORCID = "0000-0002-9814-092X")),
   person(given = "Elizabeth", family = "Wenk", role = c("aut", "ctb"), email = "e.wenk@unsw.edu.au", comment = c(ORCID = "0000-0001-5640-5910")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,9 @@
-# APCalign 0.1.3
+# APCalign 0.1.4
 
 
 * Better handling of errors when API/network connection is down for `load_taxonomic_resources` 
 
 * Refined testing for `load_taxonomic_resources` 
 
-* Revised hex - now is .svg!
 
-* Minor update to documentation for 'create_taxonomic_update_lookup'
 

--- a/R/load_taxonomic_resources.R
+++ b/R/load_taxonomic_resources.R
@@ -381,9 +381,10 @@ default_version <- function() {
     
     response <- httr::GET(url)
   
-  if(httr::http_error(response)){
+  if(httr::http_error(response) | !network){
     message("API currently down, try again later")
-  } 
+    return(invisible(NULL))
+  } else
   release_data <- httr::content(response, "text") |> jsonlite::fromJSON()
   
   # Pull out versions


### PR DESCRIPTION
Addressing [CRAN issue](https://cran.r-project.org/web/checks/check_results_APCalign.html) when API for GitHub was down
- Important addition of `return(NULL)` after message