### PR TITLE
possible work around for arrow and fixing current data download bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests:
     here,
     testthat (>= 3.0.0)
 Remotes:
-    r-universe::apache.r-universe.dev
+    arrow::apache.r-universe.dev
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     httr,
     jsonlite,
     curl,
+    arrow,
     rlang
 Suggests:
     janitor,
@@ -37,8 +38,7 @@ Suggests:
     kableExtra,
     here,
     testthat (>= 3.0.0)
-Remotes:
-    arrow::apache.r-universe.dev
+Remotes: apache/arrow
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     dplyr,
     stringr,
     stringi,
-    arrow,
     crayon,
     httr,
     jsonlite,
@@ -38,6 +37,8 @@ Suggests:
     kableExtra,
     here,
     testthat (>= 3.0.0)
+Remotes:
+    r-universe::apache.r-universe.dev
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Config/testthat/edition: 3

--- a/R/load_taxonomic_resources.R
+++ b/R/load_taxonomic_resources.R
@@ -334,11 +334,6 @@ dataset_access_function <-
                 modified = readr::col_datetime(format = "")
               )
           )
-
-        on.exit(
-          close( "https://biodiversity.org.au/nsl/services/export/taxonCsv"),
-          close( "https://biodiversity.org.au/nsl/services/export/namesCsv")
-                )
       }, error = function(e) rlang::abort("Taxonomic resources not currently available, try again later")
       )
     }


### PR DESCRIPTION
small update for downloading current APC data and should maybe be a better way to load arrow across platforms. not 100% sure r-universe will load across platforms, but CI should check this.  