### PR TITLE
Added skip if github is down

### DIFF
--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -1,4 +1,6 @@
 test_that("Complains when network is down", {
+  skip_if_offline(host = "api.github.com")
+
   Sys.setenv("NETWORK_UP" = FALSE)
   expect_message(default_version())
   expect_message(dataset_access_function())


### PR DESCRIPTION
https://testthat.r-lib.org/reference/skip.html

Safe guarding our tests if github is down
