### PR TITLE
Identifier string fix

### DIFF
--- a/R/align_taxa.R
+++ b/R/align_taxa.R
@@ -114,6 +114,7 @@ align_taxa <- function(original_name,
         cleaned_name = character(0L),
         aligned_name = character(0L),
         taxonomic_dataset = character(0L),
+        identifier = character(0L),
         known = logical(0L),
         checked = logical(0L)
       )
@@ -132,6 +133,7 @@ align_taxa <- function(original_name,
             !is.na(original_name) & 
             !original_name %in% taxa_raw$original_name
             ),
+        identifier = identifier,
         cleaned_name = NA_character_,
         stripped_name = NA_character_,
         stripped_name2 = NA_character_,
@@ -162,8 +164,9 @@ align_taxa <- function(original_name,
         known = FALSE
       )
     ) %>% 
-    # take unique values so each name only processed once
-    dplyr::filter(!duplicated(original_name)) %>%
+    # take unique values of original name by identifier combinations
+    # so each name only processed once (or multiple times if unique identifiers)
+    dplyr::filter(!duplicated(paste0(original_name, identifier))) %>%
     dplyr::filter(original_name %>% standardise_names() != "")
   
   if (all(taxa$tocheck$checked)|all(is.na(taxa$tocheck$checked))) {
@@ -224,14 +227,16 @@ align_taxa <- function(original_name,
   } else {
      taxa <-
       taxa %>%
-      dplyr::select(original_name, cleaned_name, aligned_name, taxonomic_dataset, taxon_rank, aligned_reason, alignment_code)      
+      dplyr::select(original_name, cleaned_name, aligned_name, taxonomic_dataset, taxon_rank, aligned_reason, alignment_code, identifier)      
   }
 
   # Assemble output in the order of the input
   # by joining results into a tibble with inputs as column
   taxa <-
-    dplyr::tibble(original_name = original_name) %>%
-    dplyr::left_join(by = "original_name", taxa)
+    dplyr::tibble(original_name = original_name, identifier = identifier) %>%
+    dplyr::left_join(by = c("original_name", "identifier"), taxa) %>%
+    # can remove column identifier now that matches are complete
+    dplyr::select(-identifier)
   
   ## save outputs to file, useful for caching results 
   if (!is.null(output)) {

--- a/tests/testthat/test-operation_outputs.R
+++ b/tests/testthat/test-operation_outputs.R
@@ -188,7 +188,11 @@ test_that("taxon name alignment matches and updates work as expected", {
   # for update_taxonomy, there are cases where the algorithm doesn't produce a desired result (suggested_name != updated_name)
   # these are known and expected failures.
   expect_equal(benchmarks$updated_name_passes, output_updates$test_column)
-
+}
+)
+  
+test_that("fuzzy_match works as expected when n_allowed > 1", {
+    
   expect_length(
     fuzzy_match(
       txt = "Danksia",
@@ -212,5 +216,68 @@ test_that("taxon name alignment matches and updates work as expected", {
     ),
     2
   ) 
+}
+)
+
+test_that("identifier column works when mismatch between unique taxa and unique identifiers", {
+  taxa <-
+    c(
+      "Banksia integrifolia",
+      "Acacia longifolia",
+      "Commersonia rosea",
+      "Thelymitra pauciflora",
+      "Justicia procumbens",
+      "Hibbertia stricta",
+      "Rostellularia adscendens",
+      "Hibbertia sericea",
+      "Hibbertia sp.",
+      "Athrotaxis laxiflolia",
+      "Genoplesium insigne",
+      "Polypogon viridis",
+      "Acacia aneura",
+      "Acacia paraneura",
+      "Galactia striata",
+      "Acacia sp.",
+      "Acacia sp.",
+      "Acacia sp.",
+      "Acacia sp."
+    )
   
-  })
+  identifiers <-
+    c(
+      "message_01",
+      "message_02",
+      "message_03",
+      "message_04",
+      "message_05",
+      "message_06",
+      "message_07",
+      "message_08",
+      "message_09",
+      "message_10",
+      "message_11",
+      "message_12",
+      "message_13",
+      "message_14",
+      "message_15",
+      "message_16",
+      "message_17",
+      "message_18",
+      "message_19"
+    )
+  
+  output <-
+    align_taxa(
+      original_name = taxa,
+      identifier = identifiers,
+      resources = resources,
+      full = TRUE,
+      quiet = TRUE
+    )
+  
+  expect_length(
+    output$aligned_name, 19
+  )
+}  
+  
+)


### PR DESCRIPTION
Fixes a known issue when reading in identifiers from a column - if there were two rows with distinct identifiers but the same original_name, the code broke.

Identifier has now been added to lines of code in `align_taxa.R` that were determining how many distinct rows to retain for matching.

There will now, occasionally, be repeat original names run through the match algorithms, but this is necessary to attach the correct identifier to each instance of the original name.

I've also added a new test.

Should solve issue #177