### PR TITLE
Option if fuzzy_match accepted list is empty for a given letter

### DIFF
--- a/R/fuzzy_match.R
+++ b/R/fuzzy_match.R
@@ -62,6 +62,7 @@ fuzzy_match <- function(txt, accepted_list, max_distance_abs, max_distance_rel, 
                     unique()
 
   ## identify the number of characters that must change for the text string to match each of the possible accepted names
+  if (length(accepted_list) > 0) {
   distance_c <- stringdist::stringdist(txt, accepted_list, method = "dl")
   
   ## identify the minimum number of characters that must change for the text string to match a string in the list of accepted names
@@ -80,6 +81,10 @@ fuzzy_match <- function(txt, accepted_list, max_distance_abs, max_distance_rel, 
     ## Solution has up to n_allowed matches
     length(potential_matches) <= n_allowed
     ) ) { 
+    return(NA)
+  }
+  
+  } else {
     return(NA)
   }
   

--- a/tests/testthat/test-operation_outputs.R
+++ b/tests/testthat/test-operation_outputs.R
@@ -281,3 +281,17 @@ test_that("identifier column works when mismatch between unique taxa and unique 
 }  
   
 )
+
+test_that("No warnings if trying to match input name to empty accepted name set.", {
+  
+ expect_equal(
+    fuzzy_match(
+      txt = "Kallstroemie",
+      accepted_list = resources$family_synonym$canonical_name,
+      max_distance_abs = 2, 
+      max_distance_rel = 0.3, 
+      n_allowed = 1,
+      epithet_letters = 1
+    ), NA)
+}
+)


### PR DESCRIPTION
Need to add `if else` loop to only search for fuzzy matches if the subset accepted list (with same first letter) is non-empty. If there were no strings on the accepted list with the same first letter as the input text, warnings were generated.