### PR TITLE
docs: AusTraits family cross-linking, acknowledgements & citations

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,100 @@
+# ------------------------------------------------
+# CITATION.cff file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# ------------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "APCalign" in publications use:'
+type: software
+license: MIT
+title: 'APCalign: Resolving Plant Taxon Names Using the Australian Plant Census'
+version: 2.0.0
+doi: 10.1071/BT24014
+identifiers:
+- type: doi
+  value: 10.32614/CRAN.package.APCalign
+- type: url
+  value: https://doi.org/10.1071/BT24014
+abstract: The process of resolving and updating taxon names is necessary when working
+  with biodiversity data. 'APCalign' uses the Australian Plant Census (APC) and the
+  Australian Plant Name Index (APNI) to align and update plant taxon names to current,
+  accepted standards. 'APCalign' also supplies information about the establishment
+  status (i.e. native or introduced) of plant taxa across different states/territories.
+authors:
+- family-names: Wenk
+  given-names: Elizabeth
+  email: e.wenk@unsw.edu.au
+  orcid: https://orcid.org/0000-0001-5640-5910
+- family-names: Falster
+  given-names: Daniel
+  email: daniel.falster@unsw.edu.au
+  orcid: https://orcid.org/0000-0002-9814-092X
+- family-names: Cornwell
+  given-names: Will
+  email: w.cornwell@unsw.edu.au
+  orcid: https://orcid.org/0000-0003-4080-4073
+- family-names: Kar
+  given-names: Fonti
+  email: f.kar@unsw.edu.au
+  orcid: https://orcid.org/0000-0002-2760-3974
+preferred-citation:
+  type: article
+  title: 'APCalign: an R package workflow and app for aligning and updating flora
+    names to the Australian Plant Census'
+  authors:
+  - family-names: Wenk
+    given-names: Elizabeth
+    email: e.wenk@unsw.edu.au
+    orcid: https://orcid.org/0000-0001-5640-5910
+  - family-names: Cornwell
+    given-names: Will
+    email: w.cornwell@unsw.edu.au
+    orcid: https://orcid.org/0000-0003-4080-4073
+  - family-names: Fuchs
+    given-names: Ann
+    email: anne.fuchs@dcceew.gov.au
+    orcid: https://orcid.org/0000-0001-5737-8803
+  - family-names: Kar
+    given-names: Fonti
+    email: f.kar@unsw.edu.au
+    orcid: https://orcid.org/0000-0002-2760-3974
+  - family-names: Monro
+    given-names: Anna
+    email: anna.monro@dcceew.gov.au
+    orcid: https://orcid.org/0000-0001-9031-2670
+  - family-names: Sauquet
+    given-names: Herve
+    email: herve.sauquet@botanicgardens.nsw.gov.au
+    orcid: https://orcid.org/0000-0001-8305-3236
+  - family-names: Stephens
+    given-names: Ruby
+    email: stephenseruby@gmail.com
+    orcid: https://orcid.org/0000-0002-3767-2690
+  - family-names: Falster
+    given-names: Daniel
+    email: daniel.falster@unsw.edu.au
+    orcid: https://orcid.org/0000-0002-9814-092X
+  journal: Australian Journal of Botany
+  volume: '72'
+  issue: '4'
+  year: '2024'
+  publisher:
+    name: CSIRO Publishing
+  notes: 'R package version: 2.0.0'
+  url: https://doi.org/10.1071/BT24014
+  doi: 10.1071/BT24014
+repository: https://CRAN.R-project.org/package=APCalign
+repository-code: https://github.com/traitecoevo/APCalign
+url: https://traitecoevo.github.io/APCalign/
+contact:
+- family-names: Wenk
+  given-names: Elizabeth
+  email: e.wenk@unsw.edu.au
+  orcid: https://orcid.org/0000-0001-5640-5910
+keywords:
+- r-package
+- taxonomy
+- australia
+- plants
+- flora
+

--- a/README.Rmd
+++ b/README.Rmd
@@ -57,7 +57,7 @@ install.packages("remotes")
 remotes::install_github("traitecoevo/APCalign")
 ```
 
-Or for the ShinyApp head to [unsw.shinyapps.io/APCalign-app](https://unsw.shinyapps.io/APCalign-app/)
+Or for the ShinyApp head to [app.austraits.org/APCalign-app](https://app.austraits.org/APCalign-app/)
 
 ## A quick demo
 
@@ -171,3 +171,20 @@ read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta
 in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
 knowledge and governance hub — before filing.
 
+
+## Acknowledgements
+
+AusTraits is made possible by contributions from our partner organisations — the
+[University of New South Wales](https://www.unsw.edu.au/),
+[Western Sydney University](https://www.westernsydney.edu.au/),
+[Botanic Gardens of Sydney](https://www.botanicgardens.org.au/),
+[the University of Melbourne](https://www.unimelb.edu.au/),
+the [Atlas of Living Australia](https://www.ala.org.au/), and the Australian Government
+[Department of Climate Change, Energy, the Environment and Water](https://www.dcceew.gov.au) — and
+from our [advisory board, data contributors, and past partners](https://austraits.org/team/team-partners.html).
+
+AusTraits is a co-investment partnership with the
+[Australian Research Data Commons](https://ardc.edu.au/) (ARDC) through the Planet Research Data
+Commons ([DOI: 10.3565/nyk4-4r91](https://doi.org/10.3565/nyk4-4r91)). The ARDC is enabled by the
+Australian Government's [National Collaborative Research Infrastructure Strategy](https://www.education.gov.au/ncris)
+(NCRIS).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ remotes::install_github("traitecoevo/APCalign")
 ```
 
 Or for the ShinyApp head to
-[unsw.shinyapps.io/APCalign-app](https://unsw.shinyapps.io/APCalign-app/)
+[app.austraits.org/APCalign-app](https://app.austraits.org/APCalign-app/)
 
 ## A quick demo
 
@@ -226,7 +226,7 @@ citation("APCalign")
 #>   Wenk E, Cornwell W, Fuchs A, Kar F, Monro A, Sauquet H, Stephens R,
 #>   Falster D (2024). "APCalign: an R package workflow and app for
 #>   aligning and updating flora names to the Australian Plant Census."
-#>   _Australian Journal of Botany_, *72*(4). R package version: 1.1.4,
+#>   _Australian Journal of Botany_, *72*(4). R package version: 2.0.0,
 #>   <https://doi.org/10.1071/BT24014>.
 #> 
 #> A BibTeX entry for LaTeX users is
@@ -239,7 +239,7 @@ citation("APCalign")
 #>     number = {4},
 #>     year = {2024},
 #>     publisher = {CSIRO Publishing},
-#>     note = {R package version: 1.1.4},
+#>     note = {R package version: 2.0.0},
 #>     url = {https://doi.org/10.1071/BT24014},
 #>   }
 ```
@@ -268,3 +268,20 @@ Contributing? Issues across the family are tracked on one board,
 read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
 in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
 knowledge and governance hub — before filing.
+
+## Acknowledgements
+
+AusTraits is made possible by contributions from our partner organisations — the
+[University of New South Wales](https://www.unsw.edu.au/),
+[Western Sydney University](https://www.westernsydney.edu.au/),
+[Botanic Gardens of Sydney](https://www.botanicgardens.org.au/),
+[the University of Melbourne](https://www.unimelb.edu.au/),
+the [Atlas of Living Australia](https://www.ala.org.au/), and the Australian Government
+[Department of Climate Change, Energy, the Environment and Water](https://www.dcceew.gov.au) — and
+from our [advisory board, data contributors, and past partners](https://austraits.org/team/team-partners.html).
+
+AusTraits is a co-investment partnership with the
+[Australian Research Data Commons](https://ardc.edu.au/) (ARDC) through the Planet Research Data
+Commons ([DOI: 10.3565/nyk4-4r91](https://doi.org/10.3565/nyk4-4r91)). The ARDC is enabled by the
+Australian Government's [National Collaborative Research Infrastructure Strategy](https://www.education.gov.au/ncris)
+(NCRIS).

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -16,6 +16,6 @@ bibentry(
   number   = 4,
   year     = 2024,
   publisher="CSIRO Publishing",
-  note     = "R package version: 1.1.4",
+  note     = paste("R package version:", meta$Version),
   url      = "https://doi.org/10.1071/BT24014"
 )


### PR DESCRIPTION
Part of the family-wide README usability pass (see the plan in `traitecoevo/austraits-meta` → `plans/family-usability-overhaul.md`).

Standardises across the AusTraits family:
- the **AusTraits family** cross-link block (→ austraits.org, board #9, `austraits-meta`)
- the canonical **partner + ARDC/NCRIS co-investment acknowledgement** (NCRIS "enabled by")
- a **How to cite** section drawn from the family citation set

...plus repo-specific README fixes. Citation and acknowledgement wording come from the canonical sources in `austraits-meta` (`references/`, `acknowledgements.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)